### PR TITLE
fix(ci-cd|release): initial goreleaser configuration syntax error

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,12 +45,12 @@ signs:
     artifacts: checksum
     args: [
       "--batch",
-      "--local-user"
+      "--local-user",
       "{{ .Env.GPG_FINGERPRINT }}",
       "--output",
       "${signature}",
       "--detach-sign",
-      "${artifact}"
+      "${artifact}",
     ]
     output: true
 


### PR DESCRIPTION
Fixes: https://github.com/kiwicom/terraform-provider-monte-carlo/pull/6

Syntax error in the configuration caused pipeline to fail:
pipeline - [https://github.com/kiwicom/terraform-provider-monte-carlo/actions/runs/6326730418/job/17180925402](https://github.com/kiwicom/terraform-provider-monte-carlo/actions/runs/6326730418/job/17180925402)
```
yaml: line 45: did not find expected ',' or ']'
```